### PR TITLE
Add OpenDNS Family Shield IPv6 addresses

### DIFF
--- a/docs/guides/dns/upstream-dns-providers.md
+++ b/docs/guides/dns/upstream-dns-providers.md
@@ -39,6 +39,8 @@ OpenDNS also provides the OpenDNS FamilyShield (free)- option. The service block
 
 - 208.67.222.123
 - 208.67.220.123
+- 2620:119:35::123 (IPv6)
+- 2620:119:53::123 (IPv6)
 
 [More information on OpenDNS FamilyShield](https://www.opendns.com/setupguide/#familyshield) + [OpenDNS FamilyShield introduction Blog](https://umbrella.cisco.com/blog/introducing-familyshield-parental-controls)
 


### PR DESCRIPTION
As discussed in [Discourse](https://discourse.pi-hole.net/t/mention-opendns-family-shield-ipv6-addresses-in-the-docs/64342). IPv6 addresses from [here](https://support.opendns.com/hc/en-us/articles/360039659971-DNSSEC-General-Availability). They work in my setup.